### PR TITLE
_socket should be builtin on MSVC, just like datetime.  Because datet…

### DIFF
--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -20,7 +20,12 @@ add_python_extension(crypt REQUIRES HAVE_LIBCRYPT SOURCES cryptmodule.c LIBRARIE
 add_python_extension(cStringIO SOURCES cStringIO.c)
 add_python_extension(_csv SOURCES _csv.c)
 add_python_extension(_ctypes_test SOURCES _ctypes/_ctypes_test.c)
-add_python_extension(datetime ${MSVC_BUILTIN} REQUIRES HAVE_LIBM SOURCES datetimemodule.c timemodule.c LIBRARIES ${M_LIBRARIES})
+if (MSVC)
+# Because datetime is builtin on MSVC, no need to add timemodule.c
+  add_python_extension(datetime ${MSVC_BUILTIN} REQUIRES HAVE_LIBM SOURCES datetimemodule.c LIBRARIES ${M_LIBRARIES})
+else ()
+  add_python_extension(datetime ${MSVC_BUILTIN} REQUIRES HAVE_LIBM SOURCES datetimemodule.c timemodule.c LIBRARIES ${M_LIBRARIES})
+endif ()
 if(ENABLE_DATETIME AND UNIX)
     set_property(SOURCE ${SRC_DIR}/Modules/datetimemodule.c PROPERTY COMPILE_FLAGS -Wno-unused-value)
 endif()
@@ -118,6 +123,7 @@ endif(WIN32)
 set(_socket_SOURCES socketmodule.c)
 if(WIN32)
     add_python_extension(_socket
+        ${MSVC_BUILTIN}
         REQUIRES HAVE_LIBM
         SOURCES ${_socket_SOURCES}
         DEFINITIONS EAI_ADDRFAMILY


### PR DESCRIPTION
This is a micro pull request to get _socket to work on Windows builds.  Also removes timemodule.c
from datetime on Windows, as not needed, since built int.