### PR TITLE
Fix propogated compile definitions

### DIFF
--- a/cmake/Extensions.cmake
+++ b/cmake/Extensions.cmake
@@ -37,6 +37,14 @@
 # leading underscores.  So add_python_extension(_foo ...) will create the
 # options ENABLE_FOO and BUILTIN_FOO.
 
+macro(append_list_in_cache L)
+  if(ARGN)
+    list(APPEND ${L} ${ARGN})
+    list(REMOVE_DUPLICATES ${L})
+    set(${L} "${${L}}" CACHE INTERNAL "" FORCE)
+  endif()
+endmacro()
+
 function(add_python_extension name)
     set(options BUILTIN)
     set(oneValueArgs)
@@ -107,11 +115,11 @@ function(add_python_extension name)
 
     if(BUILTIN_${upper_name})
         # This will be compiled into libpython instead of as a separate library
-        set(builtin_extensions "${builtin_extensions}${name};" CACHE INTERNAL "" FORCE)
-        set(builtin_source "${builtin_source}${absolute_sources};" CACHE INTERNAL "" FORCE)
-        set(builtin_link_libraries "${builtin_link_libraries}${ADD_PYTHON_EXTENSION_LIBRARIES};" CACHE INTERNAL "" FORCE)
-        set(builtin_includedirs "${builtin_includedirs}${ADD_PYTHON_EXTENSION_INCLUDEDIRS};" CACHE INTERNAL "" FORCE)
-        set(builtin_definitions "${builtin_definitions}${ADD_PYTHON_EXTENSION_DEFINITIONS};" CACHE INTERNAL "" FORCE)
+        append_list_in_cache(builtin_extensions ${name})
+        append_list_in_cache(builtin_source ${absolute_sources})
+        append_list_in_cache(builtin_link_libraries ${ADD_PYTHON_EXTENSION_LIBRARIES})
+        append_list_in_cache(builtin_includedirs ${ADD_PYTHON_EXTENSION_INCLUDEDIRS})
+        append_list_in_cache(builtin_definitions ${ADD_PYTHON_EXTENSION_DEFINITIONS})
     elseif(WIN32 AND NOT BUILD_SHARED)
         # Extensions cannot be built against a static libpython on windows
     else(BUILTIN_${upper_name})

--- a/cmake/extensions/CMakeLists.txt
+++ b/cmake/extensions/CMakeLists.txt
@@ -208,6 +208,7 @@ else(WIN32)
         #            _ctypes/libffi_osx/${_libffi_system_dir}/darwin64.S
         #    INCLUDEDIRS ${SRC_DIR}/Modules/_ctypes/libffi/src/${_libffi_system_dir}
         #                ${SRC_DIR}/Modules/_ctypes/libffi/include
+        #    DEFINITIONS USE_DL_PREFIX
         #)
     else(APPLE)
         if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
@@ -231,6 +232,7 @@ else(WIN32)
             INCLUDEDIRS ${SRC_DIR}/Modules/_ctypes/libffi/src/${_libffi_system_dir}
                         ${SRC_DIR}/Modules/_ctypes/libffi/include
                         ${CMAKE_SOURCE_DIR}/cmake # For ffi.h and fficonfig.h
+            DEFINITIONS USE_DL_PREFIX
         )
     endif(APPLE)
 endif(WIN32)

--- a/cmake/libpython/CMakeLists.txt
+++ b/cmake/libpython/CMakeLists.txt
@@ -1,5 +1,8 @@
 add_definitions(-DPy_BUILD_CORE)
 add_definitions(-DNDEBUG)
+if(HAVE_MEMMOVE)
+  add_definitions(-DHAVE_MEMMOVE=1)
+endif()
 
 set(LIBPYTHON_SOURCES
     ${CMAKE_BINARY_DIR}/CMakeFiles/config.c
@@ -237,7 +240,7 @@ function(add_libpython name type)
     )
 
     if(builtin_definitions)
-        set_target_properties(${name} PROPERTIES COMPILE_DEFINITIONS "${builtin_definitions}")
+        target_compile_definitions(${name} PUBLIC "${builtin_definitions}")
     endif(builtin_definitions)
 
     # Export target
@@ -268,8 +271,8 @@ endif(BUILD_SHARED)
 
 if(BUILD_STATIC)
     add_libpython(libpython-static STATIC)
+    target_compile_definitions(libpython-static PUBLIC Py_NO_ENABLE_SHARED)
     set_target_properties(libpython-static PROPERTIES
-        COMPILE_DEFINITIONS Py_NO_ENABLE_SHARED
         ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${LIBPYTHON_STATIC_ARCHIVEDIR}
     )
     install(TARGETS libpython-static ARCHIVE DESTINATION ${PYTHONHOME}/config/)


### PR DESCRIPTION
Not all compile definitions were actually making it down to libpython, especially when using builtin for all extensions.  This works now.